### PR TITLE
[#8] feature: 퀴즈 생성 레이아웃 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "react/react-in-jsx-scope": "off",
-    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "@typescript-eslint/no-use-before-define": 0
   }
 }

--- a/src/components/Header/ContentHeader.tsx
+++ b/src/components/Header/ContentHeader.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import { PageContentType } from '../../types';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: center;
+  padding: 20px 0px;
+
+  .main-text {
+    font-family: NotoSansBold;
+    font-size: 16px;
+    color: ${(props) => props.theme.colors.grayScale02};
+  }
+
+  .sub-text {
+    font-family: NotoSansMedium;
+    font-size: 12px;
+    color: ${(props) => props.theme.colors.grayScale03};
+  }
+`;
+
+function ContentHeader({ text }: { text: PageContentType }) {
+  return (
+    <Container>
+      <div className="main-text">{text.main}</div>
+      <div className="sub-text">{text.sub}</div>
+    </Container>
+  );
+}
+
+export default ContentHeader;

--- a/src/components/Header/ContentHeader.tsx
+++ b/src/components/Header/ContentHeader.tsx
@@ -1,6 +1,15 @@
 import styled from 'styled-components';
 import { PageContentType } from '../../types';
 
+function ContentHeader({ text }: { text: PageContentType }) {
+  return (
+    <Container>
+      <div className="main-text">{text.main}</div>
+      <div className="sub-text">{text.sub}</div>
+    </Container>
+  );
+}
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -20,14 +29,5 @@ const Container = styled.div`
     color: ${(props) => props.theme.colors.grayScale03};
   }
 `;
-
-function ContentHeader({ text }: { text: PageContentType }) {
-  return (
-    <Container>
-      <div className="main-text">{text.main}</div>
-      <div className="sub-text">{text.sub}</div>
-    </Container>
-  );
-}
 
 export default ContentHeader;

--- a/src/components/Header/MenuBar.tsx
+++ b/src/components/Header/MenuBar.tsx
@@ -3,6 +3,43 @@ import styled from 'styled-components';
 import { useState } from 'react';
 import { HEADER_MENU_LIST } from '../../constants';
 
+function MenuBar() {
+  const location = useLocation();
+  const [login, setLogin] = useState<boolean>(true); // 로그인 여부를 표현하기 위한 임시 수단
+
+  const handleLogout = () => {
+    // TODO: 로그아웃 기능 구현
+    setLogin(false);
+  };
+
+  const handleLogin = () => {
+    // TODO: 로그인 기능 구현
+    setLogin(true);
+  };
+
+  return (
+    <Container>
+      {HEADER_MENU_LIST.map((menu) => (
+        <Link key={menu.menu} to={menu.path} style={{ textDecoration: 'none' }}>
+          <MenuButton className={`menu-button ${location.pathname === menu.path ? 'active' : undefined}`}>
+            {menu.menu}
+          </MenuButton>
+        </Link>
+      ))}
+      {login ? (
+        <MenuButton className="logout-button" type="button" onClick={handleLogout}>
+          로그아웃
+        </MenuButton>
+      ) : (
+        <MenuButton className="login-button" type="button" onClick={handleLogin}>
+          <img alt="kakao-login-icon" src="/src/assets/icons/icon_kakao.svg" />
+          <span>Login</span>
+        </MenuButton>
+      )}
+    </Container>
+  );
+}
+
 const Container = styled.div`
   display: flex;
   flex-direction: row;
@@ -52,42 +89,5 @@ const MenuButton = styled.button`
   border: none;
   cursor: pointer;
 `;
-
-function MenuBar() {
-  const location = useLocation();
-  const [login, setLogin] = useState<boolean>(true); // 로그인 여부를 표현하기 위한 임시 수단
-
-  const handleLogout = () => {
-    // TODO: 로그아웃 기능 구현
-    setLogin(false);
-  };
-
-  const handleLogin = () => {
-    // TODO: 로그인 기능 구현
-    setLogin(true);
-  };
-
-  return (
-    <Container>
-      {HEADER_MENU_LIST.map((menu) => (
-        <Link key={menu.menu} to={menu.path} style={{ textDecoration: 'none' }}>
-          <MenuButton className={`menu-button ${location.pathname === menu.path ? 'active' : undefined}`}>
-            {menu.menu}
-          </MenuButton>
-        </Link>
-      ))}
-      {login ? (
-        <MenuButton className="logout-button" type="button" onClick={handleLogout}>
-          로그아웃
-        </MenuButton>
-      ) : (
-        <MenuButton className="login-button" type="button" onClick={handleLogin}>
-          <img alt="kakao-login-icon" src="/src/assets/icons/icon_kakao.svg" />
-          <span>Login</span>
-        </MenuButton>
-      )}
-    </Container>
-  );
-}
 
 export default MenuBar;

--- a/src/components/Header/MenuBar.tsx
+++ b/src/components/Header/MenuBar.tsx
@@ -1,7 +1,7 @@
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { useState } from 'react';
-import HEADER_MENU_LIST from '../../constants';
+import { HEADER_MENU_LIST } from '../../constants';
 
 const Container = styled.div`
   display: flex;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -2,14 +2,6 @@ import styled from 'styled-components';
 import MainWrapper from '../Wrapper/MainWrapper';
 import MenuBar from './MenuBar';
 
-const Container = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: 64px;
-  background-color: ${(props) => props.theme.colors.mainMintLight};
-`;
-
 function Header() {
   return (
     <MainWrapper>
@@ -20,5 +12,13 @@ function Header() {
     </MainWrapper>
   );
 }
+
+const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 64px;
+  background-color: ${(props) => props.theme.colors.mainMintLight};
+`;
 
 export default Header;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Wrapper from '../Wrapper/Wrapper';
+import MainWrapper from '../Wrapper/MainWrapper';
 import MenuBar from './MenuBar';
 
 const Container = styled.div`
@@ -12,12 +12,12 @@ const Container = styled.div`
 
 function Header() {
   return (
-    <Wrapper>
+    <MainWrapper>
       <Container>
         <img alt="main-logo" src="/src/assets/logo/logo_main.svg" width="88px" />
         <MenuBar />
       </Container>
-    </Wrapper>
+    </MainWrapper>
   );
 }
 

--- a/src/components/TapBar/TabBar.tsx
+++ b/src/components/TapBar/TabBar.tsx
@@ -1,5 +1,23 @@
 import styled from 'styled-components';
 
+interface TabBarProps {
+  tabList: string[];
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+}
+
+function TabBar({ tabList, activeTab, setActiveTab }: TabBarProps) {
+  return (
+    <Wrapper>
+      {tabList.map((tab) => (
+        <TabButton key={tab} $active={tab === activeTab} onClick={() => setActiveTab(tab)}>
+          {tab}
+        </TabButton>
+      ))}
+    </Wrapper>
+  );
+}
+
 const Wrapper = styled.div`
   width: 100%;
   display: flex;
@@ -25,23 +43,5 @@ const TabButton = styled.div<{ $active: boolean }>`
   border-color: ${(props) => (props.$active ? props.theme.colors.mainMint : 'transparent')};
   cursor: pointer;
 `;
-
-interface TabBarProps {
-  tabList: string[];
-  activeTab: string;
-  setActiveTab: (tab: string) => void;
-}
-
-function TabBar({ tabList, activeTab, setActiveTab }: TabBarProps) {
-  return (
-    <Wrapper>
-      {tabList.map((tab) => (
-        <TabButton key={tab} $active={tab === activeTab} onClick={() => setActiveTab(tab)}>
-          {tab}
-        </TabButton>
-      ))}
-    </Wrapper>
-  );
-}
 
 export default TabBar;

--- a/src/components/TapBar/TabBar.tsx
+++ b/src/components/TapBar/TabBar.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+
+  border-bottom: 1px solid;
+  border-color: ${(props) => props.theme.colors.grayScale06};
+`;
+
+const TabButton = styled.div<{ $active: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 280px;
+  height: 60px;
+
+  font-family: NotoSansMedium;
+  font-size: 14px;
+  color: ${(props) => (props.$active ? props.theme.colors.mainMintDark : props.theme.colors.grayScale03)};
+  border-bottom: 2px solid;
+  border-color: ${(props) => (props.$active ? props.theme.colors.mainMint : 'transparent')};
+  cursor: pointer;
+`;
+
+interface TabBarProps {
+  tabList: string[];
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+}
+
+function TabBar({ tabList, activeTab, setActiveTab }: TabBarProps) {
+  return (
+    <Wrapper>
+      {tabList.map((tab) => (
+        <TabButton key={tab} $active={tab === activeTab} onClick={() => setActiveTab(tab)}>
+          {tab}
+        </TabButton>
+      ))}
+    </Wrapper>
+  );
+}
+
+export default TabBar;

--- a/src/components/Wrapper/MainWrapper.tsx
+++ b/src/components/Wrapper/MainWrapper.tsx
@@ -9,8 +9,10 @@ function MainWrapper({ children }: MainWrapperProps) {
 }
 
 const Container = styled.div`
-  width: 1160px;
+  min-width: 535px;
+  max-width: 1200px;
   margin: 0 auto;
+  padding: 0px 20px;
 `;
 
 export default MainWrapper;

--- a/src/components/Wrapper/MainWrapper.tsx
+++ b/src/components/Wrapper/MainWrapper.tsx
@@ -5,12 +5,12 @@ const Container = styled.div`
   margin: 0 auto;
 `;
 
-interface WrapperProps {
+interface MainWrapperProps {
   children: React.ReactNode;
 }
 
-function Wrapper({ children }: WrapperProps) {
+function MainWrapper({ children }: MainWrapperProps) {
   return <Container>{children}</Container>;
 }
 
-export default Wrapper;
+export default MainWrapper;

--- a/src/components/Wrapper/MainWrapper.tsx
+++ b/src/components/Wrapper/MainWrapper.tsx
@@ -1,10 +1,5 @@
 import styled from 'styled-components';
 
-const Container = styled.div`
-  width: 1160px;
-  margin: 0 auto;
-`;
-
 interface MainWrapperProps {
   children: React.ReactNode;
 }
@@ -12,5 +7,10 @@ interface MainWrapperProps {
 function MainWrapper({ children }: MainWrapperProps) {
   return <Container>{children}</Container>;
 }
+
+const Container = styled.div`
+  width: 1160px;
+  margin: 0 auto;
+`;
 
 export default MainWrapper;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,8 +1,13 @@
 // TODO : 각 메뉴 path 수정
-const HEADER_MENU_LIST = [
+export const HEADER_MENU_LIST = [
   { menu: '퀴즈 생성', path: '/' },
   { menu: '요약 정리 생성', path: '/2' },
   { menu: '저장 및 관리', path: '/3' },
 ];
 
-export default HEADER_MENU_LIST;
+export const TEXT_AI_QUIZ_CREATION = {
+  main: 'AI와 함께 혹은 자체적으로 퀴즈를 만들어보세요',
+  sub: '생성한 퀴즈는 저장 및 관리 페이지에서 확인하고 편집할 수 있습니다',
+};
+
+export const TAB_AI_QUIZ_CREATION = ['AI 퀴즈 생성', '자체 퀴즈 생성'];

--- a/src/layouts/QuizLayout.tsx
+++ b/src/layouts/QuizLayout.tsx
@@ -31,6 +31,7 @@ const Container = styled.div`
 const ChildrenContainer = styled.div`
   padding-top: 20px;
   padding-bottom: 33px;
+  width: 100%;
 `;
 
 const InnerContainer = styled.div`

--- a/src/layouts/QuizLayout.tsx
+++ b/src/layouts/QuizLayout.tsx
@@ -5,6 +5,23 @@ import TabBar from '../components/TapBar/TabBar';
 import ContentHeader from '../components/Header/ContentHeader';
 import MainWrapper from '../components/Wrapper/MainWrapper';
 
+function QuizLayout({ children }: { children: React.ReactNode }) {
+  const [activeTab, setActiveTab] = useState(TAB_AI_QUIZ_CREATION[0]);
+  return (
+    <Container>
+      <ContentHeader text={TEXT_AI_QUIZ_CREATION} />
+      <TabBar tabList={TAB_AI_QUIZ_CREATION} activeTab={activeTab} setActiveTab={setActiveTab} />
+      <ChildrenContainer>
+        <MainWrapper>
+          <InnerContainer>{children}</InnerContainer>
+        </MainWrapper>
+      </ChildrenContainer>
+    </Container>
+  );
+}
+
+export default QuizLayout;
+
 const Container = styled.div`
   display: flex;
   flex-direction: column;
@@ -22,20 +39,3 @@ const InnerContainer = styled.div`
   border-radius: 8px;
   box-shadow: 0px 0px 4px 0px rgba(189, 189, 189, 0.28);
 `;
-
-function QuizLayout({ children }: { children: React.ReactNode }) {
-  const [activeTab, setActiveTab] = useState(TAB_AI_QUIZ_CREATION[0]);
-  return (
-    <Container>
-      <ContentHeader text={TEXT_AI_QUIZ_CREATION} />
-      <TabBar tabList={TAB_AI_QUIZ_CREATION} activeTab={activeTab} setActiveTab={setActiveTab} />
-      <ChildrenContainer>
-        <MainWrapper>
-          <InnerContainer>{children}</InnerContainer>
-        </MainWrapper>
-      </ChildrenContainer>
-    </Container>
-  );
-}
-
-export default QuizLayout;

--- a/src/layouts/QuizLayout.tsx
+++ b/src/layouts/QuizLayout.tsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+import { TAB_AI_QUIZ_CREATION, TEXT_AI_QUIZ_CREATION } from '../constants';
+import TabBar from '../components/TapBar/TabBar';
+import ContentHeader from '../components/Header/ContentHeader';
+import MainWrapper from '../components/Wrapper/MainWrapper';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ChildrenContainer = styled.div`
+  padding-top: 20px;
+  padding-bottom: 33px;
+`;
+
+const InnerContainer = styled.div`
+  background-color: ${(props) => props.theme.colors.grayScale08};
+  min-height: calc(100vh - 254px);
+  border-radius: 8px;
+  box-shadow: 0px 0px 4px 0px rgba(189, 189, 189, 0.28);
+`;
+
+function QuizLayout({ children }: { children: React.ReactNode }) {
+  const [activeTab, setActiveTab] = useState(TAB_AI_QUIZ_CREATION[0]);
+  return (
+    <Container>
+      <ContentHeader text={TEXT_AI_QUIZ_CREATION} />
+      <TabBar tabList={TAB_AI_QUIZ_CREATION} activeTab={activeTab} setActiveTab={setActiveTab} />
+      <ChildrenContainer>
+        <MainWrapper>
+          <InnerContainer>{children}</InnerContainer>
+        </MainWrapper>
+      </ChildrenContainer>
+    </Container>
+  );
+}
+
+export default QuizLayout;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,4 @@
+export interface PageContentType {
+  main: string;
+  sub: string;
+}


### PR DESCRIPTION
## 이슈 번호

#8 

## 개요

퀴즈 생성 레이아웃 구현

## 작업

- 퀴즈 생성 화면 문구
- 퀴즈 생성 탭
- 퀴즈 생성 탭 내부
  - 배경색, 테두리 요소만 적용
  - padding은 적용하지 않음

## 기타

현재 안쪽 너비는 피그마대로 1160px 고정으로 하고 작업 중입니다. 이 방식이 괜찮은지 한 번 확인하고 넘어가고 싶어요! 
```
  width: 1160px;
  margin: 0 auto;
```

### 구현 화면 (일반 데스크탑 화면)
![image](https://github.com/capstone-five-ai/Qtudy-FE/assets/87255791/91807dd1-93f5-4159-a797-88f69ae55777)

### 구현 화면 (피그마 해상도로 볼 때)
![image](https://github.com/capstone-five-ai/Qtudy-FE/assets/87255791/aac99b48-5e60-45a5-b5df-1e3d536df386)

안에 있는 home은 테스트용!

## 추가
- `@typescript-eslint/no-use-before-define` 린트 설정을 껐습니다.
  - 브랜치를 따로 파서 작업하기 번거로워서..ㅎㅎㅎ 이 브랜치에 전부 수정해뒀습니다!
- 전체 너비를 수정했습니다.
  - 기존에 설정했던 1160px 너비 + 양옆 여백(20px 씩)을 max-width로 설정했습니다.
  - min-width은 일단 헤더가 깨지지 않는 최소의 너비를 찾아 설정했습니다.
  - min-width 이하로 줄어들 때 양옆에 여백이 있어야 보기 편안할 것 같아 20px 정도 넣어둔 상태입니다.
