### PR TITLE
feature: 히스토리 api 연결

### DIFF
--- a/src/api/FileApi.ts
+++ b/src/api/FileApi.ts
@@ -1,23 +1,34 @@
+import getAccessToken from '../utils/getAccessToken';
 import apiClient from './client';
+
+const headers = {
+  Authorization: `Bearer ${getAccessToken()}`,
+};
 
 const FileApi = {
   downloadFile: async (fileId: number, pdfType: string) => {
     // 파일(file)/PDF 다운로드
-    const response = await apiClient.post(`file/downloadPdf/${fileId}`, { pdfType });
+    const response = await apiClient.post(`api/file/downloadPdf/${fileId}`, { pdfType }, { headers });
     return response.data;
   },
 
   updateFileName: async (fileId: number, newFileName: string) => {
     // 파일(file)/파일이름 업데이트
-    const response = await apiClient.patch(`file/updateFile/${fileId}`, {
-      newFileName,
-    });
+    const response = await apiClient.patch(
+      `api/file/updateFile/${fileId}`,
+      {
+        newFileName,
+      },
+      {
+        headers,
+      }
+    );
     return response.data;
   },
 
   deleteFile: async (fileId: number) => {
     // 파일(file)/AI생성 파일 삭제
-    const response = await apiClient.delete(`file/deleteFile/${fileId}`);
+    const response = await apiClient.delete(`api/file/deleteFile/${fileId}`, { headers });
     return response.data;
   },
 };

--- a/src/api/HistoryApi.ts
+++ b/src/api/HistoryApi.ts
@@ -1,21 +1,28 @@
+import getAccessToken from '../utils/getAccessToken';
 import apiClient from './client';
 
+const config = {
+  headers: {
+    Authorization: `Bearer ${getAccessToken()}`,
+  },
+};
+
 const HistoryApi = {
-  getQuizList: async () => {
+  getQuizList: async (page: number) => {
     // 문제파일(problemFile)/생성 히스토리(문제)
-    const response = await apiClient.get('file/searchAiProblemFileList');
+    const response = await apiClient.get(`api/problemFile/searchAiProblemFileList/${page}`, config);
     return response.data;
   },
 
-  getSummaryList: async () => {
+  getSummaryList: async (page: number) => {
     // 요점정리파일(summaryFile)/생성 히스토리(요점정리)
-    const response = await apiClient.get('file/searchAiSummaryFileList');
+    const response = await apiClient.get(`api/summaryFile/searchAiSummaryFileList/${page}`, config);
     return response.data;
   },
 
   getSummaryDetail: async (id: number) => {
     // 요점정리(summary)/요점정리 조회
-    const response = await apiClient.get(`summary/getSummary/${id}`);
+    const response = await apiClient.get(`api/summary/getSummary/${id}`, config);
     return response.data;
   },
 };

--- a/src/components/Button/PDFButton.tsx
+++ b/src/components/Button/PDFButton.tsx
@@ -1,9 +1,12 @@
 import styled from 'styled-components';
+import FileApi from '../../api/FileApi';
 import { ReactComponent as PDFIcon } from '../../assets/icons/pdf.svg';
 import Typography from '../Typography';
 
 type Props = {
   label: string;
+  fileId: number;
+  pdfType: 'PROBLEM' | 'ANSWER' | 'SUMMARY';
   variant?: 1 | 2;
 };
 
@@ -11,9 +14,11 @@ PDFButton.defaultProps = {
   variant: 1,
 };
 
-function PDFButton({ label, variant }: Props) {
-  const handleClickDownload = () => {
-    // TOOD: download pdf
+function PDFButton({ label, variant, fileId, pdfType }: Props) {
+  const handleClickDownload = async () => {
+    const data = await FileApi.downloadFile(fileId, pdfType);
+
+    window.location.href = data.fileUrl;
   };
 
   if (variant === 1)
@@ -31,7 +36,7 @@ function PDFButton({ label, variant }: Props) {
 
   if (variant === 2)
     return (
-      <Wrapper>
+      <Wrapper onClick={handleClickDownload}>
         <PDFIcon />
         <Typography variant="caption3" color="grayScale03">
           {label} PDF

--- a/src/pages/Management/History/HistoryList/index.tsx
+++ b/src/pages/Management/History/HistoryList/index.tsx
@@ -6,9 +6,10 @@ import HistoryItem from './HistoryItem';
 
 type Props = {
   histories: HistoryType[];
+  updateList: (page: number) => void;
 };
 
-function HistoryList({ histories }: Props) {
+function HistoryList({ histories, updateList }: Props) {
   return (
     <Wrapper>
       <Header>
@@ -39,7 +40,7 @@ function HistoryList({ histories }: Props) {
         </Delete>
       </Header>
       {histories.map((v) => (
-        <HistoryItem key={v.fileId} history={v} />
+        <HistoryItem key={v.fileId} history={v} updateList={updateList} />
       ))}
     </Wrapper>
   );

--- a/src/pages/Management/History/index.tsx
+++ b/src/pages/Management/History/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import ReactPaginate from 'react-paginate';
 import styled from 'styled-components';
+import HistoryApi from '../../../api/HistoryApi';
 import { ReactComponent as NextIcon } from '../../../assets/icons/arrow_next.svg';
 import { ReactComponent as PrevIcon } from '../../../assets/icons/arrow_prev.svg';
 import Chip from '../../../components/Chip';
@@ -15,60 +16,41 @@ function History() {
   const [filter, setFilter] = useState<'PROBLEM' | 'SUMMARY'>(PROBLEM);
   const [histories, setHistories] = useState<HistoryType[]>([]);
   const [page, setPage] = useState(1);
+  const [totalPage, setTotalPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+
+  const getQuizes = async (quizPage: number) => {
+    const response = await HistoryApi.getQuizList(quizPage);
+    const newHistories = response.content;
+    setHistories(newHistories);
+    setTotalPage(response.totalPages);
+  };
+
+  const getSummaries = async (summaryPage: number) => {
+    const response = await HistoryApi.getSummaryList(summaryPage);
+    const newHistories = response.content;
+    setHistories(newHistories);
+    setTotalPage(response.totalPages);
+  };
+
+  const updateList = useCallback(
+    (updatePage: number) => {
+      if (filter === 'PROBLEM') getQuizes(updatePage);
+      if (filter === 'SUMMARY') getSummaries(updatePage);
+      setLoading(false);
+    },
+    [filter]
+  );
 
   useEffect(() => {
-    // TODO: call api get history by page & filter
-    setHistories([
-      {
-        fileId: 3,
-        fileName: '문제파일 이름',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:55.899476',
-      },
-      {
-        fileId: 2,
-        fileName: '문제파일 이름2',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:11.143202',
-      },
-      {
-        fileId: 4,
-        fileName: '문제파일 이름2',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:11.143202',
-      },
-      {
-        fileId: 5,
-        fileName: '문제파일 이름2',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:11.143202',
-      },
-      {
-        fileId: 6,
-        fileName: '문제파일 이름2',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:11.143202',
-      },
-      {
-        fileId: 7,
-        fileName: '문제파일 이름2',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:11.143202',
-      },
-      {
-        fileId: 8,
-        fileName: '문제파일 이름2',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:11.143202',
-      },
-      {
-        fileId: 9,
-        fileName: '문제파일 이름2',
-        dtype: 'PROBLEM',
-        createTime: '2023-11-26T15:46:11.143202',
-      },
-    ]);
-  }, []);
+    if (loading) return;
+    updateList(page);
+  }, [loading, page, updateList]);
+
+  useEffect(() => {
+    updateList(1);
+    setPage(1);
+  }, [filter, updateList]);
 
   const handlePageClick = ({ selected }: { selected: number }) => {
     setPage(selected + 1);
@@ -90,12 +72,12 @@ function History() {
         </ChipWrapper>
       </Header>
       <ListWrapper>
-        <HistoryList histories={histories} />
+        <HistoryList histories={histories} updateList={updateList} />
       </ListWrapper>
       <Pagination>
         <ReactPaginate
           forcePage={page - 1}
-          pageCount={3}
+          pageCount={totalPage}
           previousLabel={<PrevIcon />}
           nextLabel={<NextIcon />}
           onPageChange={handlePageClick}

--- a/src/utils/getAccessToken.ts
+++ b/src/utils/getAccessToken.ts
@@ -1,0 +1,5 @@
+const getAccessToken = () => {
+  return localStorage.getItem('accessToken');
+};
+
+export default getAccessToken;


### PR DESCRIPTION
## 이슈 번호

#52 

## 개요

히스토리 api 연결

## 작업

- 퀴즈/요약 필터 api
- 히스토리 목록 페이지네이션
- 파일명 수정 api
- 히스토리 삭제 api
- pdf 다운로드 api 요청

## 기타

- getAccessToken 함수는 매번 localStorage의 accessToken을 동적으로 받아오기 위해 사용함
- 현재는 페이지나 필터 정보를 url params에 반영하고 있지는 않음. 추후 수정 필요!

## 스크린샷

- 페이지네이션, 필터링
![2023-12-10 21 17 37](https://github.com/capstone-five-ai/Qtudy-FE/assets/45119238/c16c0d40-bf7f-465c-a25c-52ccfdb3f1a8)

- 파일명 수정
![2023-12-10 21 18 36](https://github.com/capstone-five-ai/Qtudy-FE/assets/45119238/db2b7b8b-3331-4164-99b0-5c7bd89d4306)

- 히스토리 삭제
![2023-12-10 21 20 53](https://github.com/capstone-five-ai/Qtudy-FE/assets/45119238/7b66bdcf-b7cb-4903-933e-a6c2d6ca86fb)


- pdf 다운로드
![2023-12-10 21 19 17](https://github.com/capstone-five-ai/Qtudy-FE/assets/45119238/08fb47e6-1513-4744-aa74-033840577691)
