### PR TITLE
카테고리 공유 페이지 구현

### DIFF
--- a/src/components/Button/TwinkleButton.tsx
+++ b/src/components/Button/TwinkleButton.tsx
@@ -5,8 +5,12 @@ import Typography from '../Typography';
 
 type Props = {
   disabled: boolean;
-  onClick: () => void;
+  onClick?: () => void;
   children: ReactNode;
+};
+
+TwinkleButton.defaultProps = {
+  onClick: null,
 };
 
 function TwinkleButton({ disabled, onClick, children }: Props) {

--- a/src/components/Question/index.tsx
+++ b/src/components/Question/index.tsx
@@ -34,7 +34,11 @@ function Question({ question, questionNum }: Props) {
         {question.problemType === 'MULTIPLE' && (
           <Choice>
             {question.problemChoices?.map((choice, idx) => (
-              <Typography key={choice} variant="body2">
+              <Typography
+                key={choice}
+                variant="body2"
+                color={showAnswer && questionNum === idx + 1 ? 'mainMintDark' : 'grayScale02'}
+              >
                 {getCircleNum(idx + 1)} {choice}
               </Typography>
             ))}

--- a/src/pages/Management/MyCategory/ItemDetail/QuizItemDetail.tsx
+++ b/src/pages/Management/MyCategory/ItemDetail/QuizItemDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import LinkButton from '../../../../components/Button/LinkButton';
@@ -13,6 +13,7 @@ function QuizItemDetail() {
   const link = window.location.href;
   const navigate = useNavigate();
   const [params] = useSearchParams();
+  const [questionNum, setQuestionNum] = useState(1);
 
   const question: QuestionType = {
     problemName: '인공지능은 무엇을 모방할 수 있는 기술 및 연구 분야인가요?',
@@ -22,6 +23,12 @@ function QuizItemDetail() {
     problemType: 'MULTIPLE',
     problemChoices: ['선지1', '선지2', '선지3', '선지4'],
   };
+
+  useEffect(() => {
+    // TODO: quiestionNum에 따라 setQuestion
+    setQuestionNum(parseInt(question.problemAnswer || '1', 10));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [questionNum]);
 
   const handleMoveToList = () => {
     // TODO: state로 activeCategory도 넘겨주기
@@ -37,7 +44,7 @@ function QuizItemDetail() {
   return (
     <>
       <CategoryItemContentWrapper handleMoveToList={handleMoveToList} handleEdit={handleEdit}>
-        <Question question={question} />
+        <Question question={question} questionNum={questionNum} />
       </CategoryItemContentWrapper>
       <SideWrapper>
         <SideBar>

--- a/src/pages/Management/MyCategory/ItemDetail/QuizItemDetail.tsx
+++ b/src/pages/Management/MyCategory/ItemDetail/QuizItemDetail.tsx
@@ -10,7 +10,6 @@ import CategoryModal from '../../../../components/Modal/CategoryModal';
 
 function QuizItemDetail() {
   const [showCategoryModal, setShowCategoryModal] = useState(false);
-  const link = window.location.href;
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const [questionNum, setQuestionNum] = useState(1);
@@ -49,7 +48,7 @@ function QuizItemDetail() {
       <SideWrapper>
         <SideBar>
           <ButtonWrapper>
-            <LinkButton link={link} />
+            <LinkButton link={`management/mycategory/share?category=quiz&id=${params.get('id')}`} />
           </ButtonWrapper>
 
           <TwinkleButton disabled={false} onClick={() => setShowCategoryModal(true)}>

--- a/src/pages/Share/ShareQuiz.tsx
+++ b/src/pages/Share/ShareQuiz.tsx
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+import { useEffect, useState } from 'react';
+import Question from '../../components/Question';
+import LinkButton from '../../components/Button/LinkButton';
+import { QuestionType } from '../../types/question.type';
+import TwinkleButton from '../../components/Button/TwinkleButton';
+
+function ShareQuiz() {
+  const link = window.location.href;
+  const [questionNum, setQuestionNum] = useState(1);
+  const question: QuestionType = {
+    problemName: '인공지능은 무엇을 모방할 수 있는 기술 및 연구 분야인가요?',
+    problemAnswer: '2',
+    problemCommentary:
+      '인공지능의 목표는 인간의 인지 능력을 모방할 수 있는 지능적인 기계를 만드는 것입니다. 즉, 사람처럼 생각하고 학습하며 문제를 해결할 수 있는 기계를 개발하는 것이 목표입니다.',
+    problemType: 'MULTIPLE',
+    problemChoices: ['선지1', '선지2', '선지3', '선지4'],
+  };
+
+  useEffect(() => {
+    // TODO: quiestionNum에 따라 setQuestion
+    setQuestionNum(parseInt(question.problemAnswer || '1', 10));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [questionNum]);
+
+  return (
+    <>
+      <QuestionContainer>
+        <Question question={question} questionNum={questionNum} />
+      </QuestionContainer>
+      <SideWrapper>
+        <SideBar>
+          <ButtonWrapper>
+            <LinkButton link={link} />
+          </ButtonWrapper>
+
+          <TwinkleButton disabled>Save to Category</TwinkleButton>
+        </SideBar>
+      </SideWrapper>
+    </>
+  );
+}
+
+export default ShareQuiz;
+
+const QuestionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 40px;
+`;
+
+const SideWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+`;
+
+const SideBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-left: 1px solid ${(props) => props.theme.colors.grayScale06};
+  margin: 24px 0;
+  padding: 0 36px;
+  flex: 1;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 30px;
+  gap: 16px;
+  justify-content: end;
+  align-items: end;
+
+  height: 100%;
+`;

--- a/src/pages/Share/ShareSummary.tsx
+++ b/src/pages/Share/ShareSummary.tsx
@@ -1,0 +1,85 @@
+import styled from 'styled-components';
+import Typography from '../../components/Typography';
+import { SummaryType } from '../../types/summary.type';
+import CopySummaryButton from '../Summary/SummaryComplete/CopySummaryButton';
+import LinkButton from '../../components/Button/LinkButton';
+import TwinkleButton from '../../components/Button/TwinkleButton';
+
+function ShareSummary() {
+  const link = window.location.href;
+  const summary: SummaryType = {
+    summaryTitle: 'Sum no.1',
+    summaryContent: `
+    인공지능(AI)은 인간의 인지 능력을 모방할 수 있는 지능적인 기계를 만드는 기술과 연구 분야입니다. 이는 음성 인식, 문제 해결, 학습, 의사 결정 및 패턴 인식과 같이 일반적으로 인간의 지능이 필요한 작업을 수행할 수 있는 컴퓨터 시스템 및 알고리즘을 개발하는 것을 포함합니다. AI는 기계 학습, 자연어 처리, 컴퓨터 비전 및 로봇 공학을 비롯한 다양한 하위 분야를 포함합니다. AI는 의료, 금융, 교통, 제조 및 엔터테인먼트 등 다양한 분야에서 응용되고 있습니다.`,
+  };
+
+  return (
+    <>
+      <MainWrapper>
+        <TitleWrapper>
+          <Typography variant="subtitle" color="mainMintDark">
+            제목
+          </Typography>
+          <Typography variant="subtitle">{summary.summaryTitle}</Typography>
+        </TitleWrapper>
+        <Typography variant="body3">{summary.summaryContent}</Typography>
+      </MainWrapper>
+
+      <SideWrapper>
+        <SideBar>
+          <ButtonWrapper>
+            <CopySummaryButton text={summary.summaryContent} />
+            <LinkButton link={link} />
+            {/* <PDFButton label="요약" /> */}
+          </ButtonWrapper>
+
+          <TwinkleButton disabled>Save to Category</TwinkleButton>
+        </SideBar>
+      </SideWrapper>
+    </>
+  );
+}
+
+export default ShareSummary;
+
+const MainWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 40px;
+
+  gap: 20px;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const SideWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+`;
+
+const SideBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-left: 1px solid ${(props) => props.theme.colors.grayScale06};
+  margin: 24px 0;
+  padding: 0 36px;
+  flex: 1;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 30px;
+  gap: 16px;
+  justify-content: end;
+  align-items: end;
+
+  height: 100%;
+`;

--- a/src/pages/Share/index.tsx
+++ b/src/pages/Share/index.tsx
@@ -1,0 +1,25 @@
+import { Navigate, useSearchParams } from 'react-router-dom';
+import MainLayout from '../../layouts/MainLayout';
+import MainWrapper from '../../components/Wrapper/MainWrapper';
+import ContentWrapper from '../../components/Wrapper/ContentWrapper';
+import ShareQuiz from './ShareQuiz';
+import ShareSummary from './ShareSummary';
+
+function Share() {
+  const [params] = useSearchParams();
+
+  if (!params.get('category') || !params.get('id')) return <Navigate to="/" replace />;
+
+  return (
+    <MainLayout contentKey="management">
+      <MainWrapper>
+        <ContentWrapper>
+          {params.get('category') === 'quiz' && <ShareQuiz />}
+          {params.get('category') === 'summary' && <ShareSummary />}
+        </ContentWrapper>
+      </MainWrapper>
+    </MainLayout>
+  );
+}
+
+export default Share;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -7,6 +7,7 @@ import Login from '../pages/login';
 import Redirection from '../pages/login/Redirection';
 import SelectService from '../pages/selectService';
 import ProtectedRoute from './ProtectedRoute';
+import Share from '../pages/Share';
 
 const routes = [
   {
@@ -49,6 +50,10 @@ const routes = [
         element: <Quiz />,
       },
       { path: 'summary/*', element: <Summary /> },
+      {
+        path: 'management/mycategory/share',
+        element: <Share />,
+      },
     ],
   },
 ];


### PR DESCRIPTION
## 이슈 번호

#33 

## 개요

카테고리 공유 페이지 구현

## 작업

- 퀴즈 아이템 상세 공유 페이지
  - 퀴즈 내용
  - 정답 및 해설
  - 링크 공유 버튼 -> 링크 공유 모달창
  - Save to Category 버튼 -> 비활성화
- 요약 아이템 상세 공유 페이지
  - 요약 내용
  - 텍스트 복사 버튼
  - 링크 공유 버튼 -> 링크 공유 모달창
  - Save to Category 버튼 -> 비활성화
