### PR TITLE
fix: accessToken 가져오지 못하고 refreshToken 계속 요청하는 버그 수정

### DIFF
--- a/src/api/AuthApi.ts
+++ b/src/api/AuthApi.ts
@@ -1,15 +1,15 @@
-import apiClient from './client';
+import apiClient, { noAuthClient } from './client';
 
 const AuthApi = {
   authKakao: async (code: string) => {
-    const response = await apiClient.get(
+    const response = await noAuthClient.get(
       `oauth/kakao/callback?code=${code}&redirectUri=${import.meta.env.VITE_REDIRECT_URI}`
     );
     return response.data;
   },
 
   login: async (accessToken: string) => {
-    const response = await apiClient.post(
+    const response = await noAuthClient.post(
       'api/oauth/login',
       {
         memberType: 'KAKAO',
@@ -24,11 +24,7 @@ const AuthApi = {
   },
 
   logout: async () => {
-    const response = await apiClient.post('api/logout', null, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    const response = await apiClient.post('api/logout', null);
 
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');

--- a/src/api/CategoryApi.ts
+++ b/src/api/CategoryApi.ts
@@ -1,12 +1,7 @@
-import getAccessToken from '../utils/getAccessToken';
 import apiClient from './client';
 
 const PAGE = 1;
 const SIZE = 20;
-
-const headers = {
-  Authorization: `Bearer ${getAccessToken()}`,
-};
 
 const CategoryApi = {
   getCategoryList: async (categoryType: string) => {
@@ -17,7 +12,6 @@ const CategoryApi = {
         size: SIZE,
         categoryType,
       },
-      headers,
     });
     return response.data;
   },
@@ -33,16 +27,10 @@ const CategoryApi = {
         memberSavedSummaryId: summaryId,
       };
     // 카테고리(Category)/요약 카테고리에 저장
-    const response = await apiClient.post(
-      `api/categorized-summary/new`,
-      {
-        categoryIdList,
-        ...id,
-      },
-      {
-        headers,
-      }
-    );
+    const response = await apiClient.post(`api/categorized-summary/new`, {
+      categoryIdList,
+      ...id,
+    });
     return response.data;
   },
 
@@ -57,23 +45,16 @@ const CategoryApi = {
         memberSavedProblemId: problemId,
       };
     // 카테고리(Category)/문제 카테고리에 저장
-    const response = await apiClient.post(
-      `api/categorized-problem/new`,
-      {
-        categoryIdList,
-        ...id,
-      },
-      {
-        headers,
-      }
-    );
+    const response = await apiClient.post(`api/categorized-problem/new`, {
+      categoryIdList,
+      ...id,
+    });
     return response.data;
   },
 
   getCategoryItems: async (categoryId: number) => {
     // 카테고리(Category)/카테고리 단건 조회
     const response = await apiClient.get(`api/category/${categoryId}`, {
-      headers,
       params: {
         page: PAGE,
         size: SIZE,
@@ -84,38 +65,24 @@ const CategoryApi = {
 
   createCategory: async (categoryName: string, categoryType: string) => {
     // 카테고리(Category)/카테고리 생성
-    const response = await apiClient.post(
-      'api/category/new',
-      {
-        categoryName,
-        categoryType,
-      },
-      {
-        headers,
-      }
-    );
+    const response = await apiClient.post('api/category/new', {
+      categoryName,
+      categoryType,
+    });
     return response.data;
   },
 
   editCategory: async (categoryId: number, categoryName: string) => {
     // 카테고리(Category)/카테고리 수정
-    const response = await apiClient.patch(
-      `api/category/edit/${categoryId}`,
-      {
-        categoryName,
-      },
-      {
-        headers,
-      }
-    );
+    const response = await apiClient.patch(`api/category/edit/${categoryId}`, {
+      categoryName,
+    });
     return response.data;
   },
 
   deleteCategory: async (categoryId: number) => {
     // 카테고리(Category)/카테고리 삭제
-    const response = await apiClient.delete(`api/category/delete/${categoryId}`, {
-      headers,
-    });
+    const response = await apiClient.delete(`api/category/delete/${categoryId}`);
     return response.data;
   },
 };

--- a/src/api/FileApi.ts
+++ b/src/api/FileApi.ts
@@ -1,21 +1,15 @@
-import getAccessToken from '../utils/getAccessToken';
 import apiClient from './client';
-
-const headers = {
-  Authorization: `Bearer ${getAccessToken()}`,
-};
 
 const FileApi = {
   downloadAIFile: async (fileId: number, pdfType: string) => {
     // 파일(file)/AI 문제, 정답 PDF 다운로드
-    const response = await apiClient.post(`api/file/downloadPdf/${fileId}`, { pdfType }, { headers });
+    const response = await apiClient.post(`api/file/downloadPdf/${fileId}`, { pdfType });
     return response.data;
   },
 
   downloadUserSummaryFile: async (memberSavedSummaryId: number) => {
     // 사용자 요약정리 파일(file)/PDF 다운로드
     const response = await apiClient.post(`api/member-saved-summary/download-pdf/${memberSavedSummaryId}`, null, {
-      headers,
       responseType: 'blob',
     });
     return response.data;
@@ -24,7 +18,6 @@ const FileApi = {
   downloadCategoryProblemFile: async (categoryId: number) => {
     // 카테고리 문제 파일(file)/PDF 다운로드
     const response = await apiClient.post(`api/categorized-problem/download-problem-pdf/${categoryId}`, null, {
-      headers,
       responseType: 'blob',
     });
     return response.data;
@@ -33,7 +26,6 @@ const FileApi = {
   downloadCategoryAnswerFile: async (categoryId: number) => {
     // 카테고리 정답 파일(file)/PDF 다운로드
     const response = await apiClient.post(`api/categorized-problem/download-answer-pdf/${categoryId}`, null, {
-      headers,
       responseType: 'blob',
     });
     return response.data;
@@ -42,7 +34,6 @@ const FileApi = {
   downloadCategorySummaryFile: async (categorizedSummaryId: number) => {
     // 카테고리 요약정리 파일(file)/PDF 다운로드
     const response = await apiClient.post(`api/categorized-summary/download-pdf/${categorizedSummaryId}`, null, {
-      headers,
       responseType: 'blob',
     });
     return response.data;
@@ -50,49 +41,31 @@ const FileApi = {
 
   updateFileName: async (fileId: number, newFileName: string) => {
     // 파일(file)/파일이름 업데이트
-    const response = await apiClient.patch(
-      `api/file/updateFile/${fileId}`,
-      {
-        newFileName,
-      },
-      {
-        headers,
-      }
-    );
+    const response = await apiClient.patch(`api/file/updateFile/${fileId}`, {
+      newFileName,
+    });
     return response.data;
   },
 
   deleteFile: async (fileId: number) => {
     // 파일(file)/AI생성 파일 삭제
-    const response = await apiClient.delete(`api/file/deleteFile/${fileId}`, { headers });
+    const response = await apiClient.delete(`api/file/deleteFile/${fileId}`);
     return response.data;
   },
 
   downloadQuiz: async (categoryId: number) => {
     // 카테고리별 문제(Categorized Problem)/카테고리별 문제 PDF(문제) 다운
-    apiClient.post(`api/categorized-problem/download-problem-pdf/${categoryId}`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    apiClient.post(`api/categorized-problem/download-problem-pdf/${categoryId}`);
   },
 
   downloadAnswer: async (categoryId: number) => {
     // 카테고리별 문제(Categorized Problem)/카테고리별 정답 PDF(정답) 다운
-    await apiClient.post(`api/categorized-problem/download-answer-pdf/${categoryId}`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    await apiClient.post(`api/categorized-problem/download-answer-pdf/${categoryId}`);
   },
 
   downloadSummary: async (categoryId: number) => {
     // 카테고리별 요약(Categorized Summary)/카테고리별 요약 정리 PDF 다운
-    await apiClient.post(`api/categorized-summary/download-pdf/${categoryId}`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    await apiClient.post(`api/categorized-summary/download-pdf/${categoryId}`);
   },
 };
 

--- a/src/api/HistoryApi.ts
+++ b/src/api/HistoryApi.ts
@@ -1,28 +1,21 @@
-import getAccessToken from '../utils/getAccessToken';
 import apiClient from './client';
-
-const config = {
-  headers: {
-    Authorization: `Bearer ${getAccessToken()}`,
-  },
-};
 
 const HistoryApi = {
   getQuizList: async (page: number) => {
     // 문제파일(problemFile)/생성 히스토리(문제)
-    const response = await apiClient.get(`api/problemFile/searchAiProblemFileList/${page}`, config);
+    const response = await apiClient.get(`api/problemFile/searchAiProblemFileList/${page}`);
     return response.data;
   },
 
   getSummaryList: async (page: number) => {
     // 요점정리파일(summaryFile)/생성 히스토리(요점정리)
-    const response = await apiClient.get(`api/summaryFile/searchAiSummaryFileList/${page}`, config);
+    const response = await apiClient.get(`api/summaryFile/searchAiSummaryFileList/${page}`);
     return response.data;
   },
 
   getSummaryDetail: async (id: number) => {
     // 요점정리(summary)/요점정리 조회
-    const response = await apiClient.get(`api/summary/getSummary/${id}`, config);
+    const response = await apiClient.get(`api/summary/getSummary/${id}`);
     return response.data;
   },
 };

--- a/src/api/QuizApi.ts
+++ b/src/api/QuizApi.ts
@@ -1,25 +1,27 @@
-import getAccessToken from '../utils/getAccessToken';
 import { QuestionType } from '../types/question.type';
 import { QuizCreationByFileType, QuizCreationByTextType } from '../types/quiz.type';
-import apiClient from './client';
-
-const headers = {
-  Authorization: `Bearer ${getAccessToken()}`,
-};
+import apiClient, { noAuthClient } from './client';
 
 const QuizApi = {
   getAllAIQuiz: async (fileId: number, isAuthenticated: boolean) => {
     // AI생성문제(problem)/파일 전체문제 조회
-    const response = await apiClient.get(`api/problem/getFileProblems/${fileId}`, isAuthenticated ? { headers } : {});
+    const path = `api/problem/getFileProblems/${fileId}`;
+    if (isAuthenticated) {
+      const response = await apiClient.get(path);
+      return response.data;
+    }
+    const response = await noAuthClient.get(path);
     return response.data;
   },
 
   getUserQuiz: async (memberSavedProblemId: number, isAuthenticated: boolean) => {
     // User생성문제(problem) 조회
-    const response = await apiClient.get(
-      `api/member-saved-problem/${memberSavedProblemId}`,
-      isAuthenticated ? { headers } : {}
-    );
+    const path = `api/member-saved-problem/${memberSavedProblemId}`;
+    if (isAuthenticated) {
+      const response = await apiClient.get(path);
+      return response.data;
+    }
+    const response = await noAuthClient.get(path);
     return response.data;
   },
 
@@ -28,7 +30,6 @@ const QuizApi = {
     const response = await apiClient.post('api/problemFile/generateProblemFileByImage', file, {
       headers: {
         'Content-Type': 'multipart/form-data',
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
       },
       params: {
         amount: option.amount,
@@ -45,7 +46,6 @@ const QuizApi = {
     const response = await apiClient.post('api/problemFile/generateProblemFileByPdf', file, {
       headers: {
         'Content-Type': 'multipart/form-data',
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
       },
       params: {
         amount: option.amount,
@@ -59,31 +59,19 @@ const QuizApi = {
 
   createByText: async ({ option, text }: QuizCreationByTextType) => {
     // 문제파일(problemFile)/Text 기반 AI 문제 생성
-    const response = await apiClient.post(
-      'api/problemFile/generateProblemFileByText',
-      {
-        amount: option.amount,
-        difficulty: option.difficulty,
-        fileName: option.fileName,
-        type: option.type,
-        text,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-        },
-      }
-    );
+    const response = await apiClient.post('api/problemFile/generateProblemFileByText', {
+      amount: option.amount,
+      difficulty: option.difficulty,
+      fileName: option.fileName,
+      type: option.type,
+      text,
+    });
     return response.data;
   },
 
   createByUser: async (newQuiz: QuestionType) => {
     // 사용자 생성 문제(MemberSavedProblem)/문제 생성
-    const response = await apiClient.post('api/member-saved-problem/new', newQuiz, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    const response = await apiClient.post('api/member-saved-problem/new', newQuiz);
     return response.data;
   },
 };

--- a/src/api/QuizCategoryApi.ts
+++ b/src/api/QuizCategoryApi.ts
@@ -4,11 +4,7 @@ import apiClient from './client';
 const QuizCategoryApi = {
   get: async (categorizedProblemId: string) => {
     // 카테고리별 문제(Categorized Problem)/카테고리별 문제 조회
-    const response = await apiClient.get(`api/categorized-problem/${categorizedProblemId}`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    const response = await apiClient.get(`api/categorized-problem/${categorizedProblemId}`);
     return response.data;
   },
 
@@ -24,21 +20,13 @@ const QuizCategoryApi = {
 
   edit: async (categorizedProblemId: string, quizData: CategoryQuizType) => {
     // 카테고리별 문제(Categorized Problem)/카테고리별 문제 수정
-    const response = await apiClient.patch(`api/categorized-problem/edit/${categorizedProblemId}`, quizData, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    const response = await apiClient.patch(`api/categorized-problem/edit/${categorizedProblemId}`, quizData);
     return response.data;
   },
 
   delete: async (categorizedProblemId: number) => {
     // 카테고리별 문제(Categorized Problem)/카테고리에 저장된 문제 삭제
-    const response = await apiClient.delete(`api/categorized-problem/delete/${categorizedProblemId}`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    const response = await apiClient.delete(`api/categorized-problem/delete/${categorizedProblemId}`);
     return response.data;
   },
 };

--- a/src/api/SummaryApi.ts
+++ b/src/api/SummaryApi.ts
@@ -1,22 +1,24 @@
-import getAccessToken from '../utils/getAccessToken';
 import { SummaryCreationByFileType, SummaryCreationByTextType, SummaryCreationByUserType } from '../types/summary.type';
-import apiClient from './client';
-
-const headers = {
-  Authorization: `Bearer ${getAccessToken()}`,
-};
+import apiClient, { noAuthClient } from './client';
 
 const SummaryApi = {
   getAISummary: async (fileId: number, isAuthenticated: boolean) => {
-    const response = await apiClient.get(`api/summary/getSummary/${fileId}`, isAuthenticated ? { headers } : {});
+    const path = `api/summary/getSummary/${fileId}`;
+    if (isAuthenticated) {
+      const response = await apiClient.get(path);
+      return response.data;
+    }
+    const response = await noAuthClient.get(path);
     return response.data;
   },
 
   getUserSummary: async (memberSavedSummaryId: number, isAuthenticated: boolean) => {
-    const response = await apiClient.get(
-      `api/member-saved-summary/${memberSavedSummaryId}`,
-      isAuthenticated ? { headers } : {}
-    );
+    const path = `api/member-saved-summary/${memberSavedSummaryId}`;
+    if (isAuthenticated) {
+      const response = await apiClient.get(path);
+      return response.data;
+    }
+    const response = await noAuthClient.get(`api/member-saved-summary/${memberSavedSummaryId}`);
     return response.data;
   },
 
@@ -25,7 +27,6 @@ const SummaryApi = {
     const response = await apiClient.post('api/summaryFile/generateSummaryFileByImage', file, {
       headers: {
         'Content-Type': 'multipart/form-data',
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
       },
       params: {
         amount: option.amount,
@@ -40,7 +41,6 @@ const SummaryApi = {
     const response = await apiClient.post('api/summaryFile/generateSummaryFileByPdf', file, {
       headers: {
         'Content-Type': 'multipart/form-data',
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
       },
       params: {
         amount: option.amount,
@@ -52,36 +52,20 @@ const SummaryApi = {
 
   createByText: async ({ option, text }: SummaryCreationByTextType) => {
     // 요점정리파일(summaryFile)/Text 기반 요점정리 생성
-    const response = await apiClient.post(
-      'api/summaryFile/generateSummaryFileByText',
-      {
-        amount: option.amount,
-        fileName: option.fileName,
-        text,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-        },
-      }
-    );
+    const response = await apiClient.post('api/summaryFile/generateSummaryFileByText', {
+      amount: option.amount,
+      fileName: option.fileName,
+      text,
+    });
     return response.data;
   },
 
   createByUser: async ({ summaryTitle, summaryContent }: SummaryCreationByUserType) => {
     // 요약정리(Summary)/요약 정리 생성
-    const response = await apiClient.post(
-      'api/member-saved-summary/new',
-      {
-        summaryTitle,
-        summaryContent,
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-        },
-      }
-    );
+    const response = await apiClient.post('api/member-saved-summary/new', {
+      summaryTitle,
+      summaryContent,
+    });
     return response.data;
   },
 };

--- a/src/api/SummaryCategoryApi.ts
+++ b/src/api/SummaryCategoryApi.ts
@@ -3,11 +3,7 @@ import apiClient from './client';
 const SummaryCategoryApi = {
   get: async (categorizedSummaryId: string) => {
     // 카테고리별 요약(Categorized Summary)/카테고리별 요약 조회
-    const response = await apiClient.get(`api/categorized-summary/${categorizedSummaryId}`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    const response = await apiClient.get(`api/categorized-summary/${categorizedSummaryId}`);
     return response.data;
   },
 
@@ -32,11 +28,7 @@ const SummaryCategoryApi = {
 
   delete: async (categorizedSummaryId: number) => {
     // 카테고리별 요약(Categorized Summary)/카테고리에 저장된 요약 삭제
-    const response = await apiClient.delete(`api/categorized-summary/delete/${categorizedSummaryId}`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-      },
-    });
+    const response = await apiClient.delete(`api/categorized-summary/delete/${categorizedSummaryId}`);
     return response.data;
   },
 };

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,10 @@
-import axios from 'axios';
+import axios, { InternalAxiosRequestConfig } from 'axios';
 
 const apiClient = axios.create({
+  baseURL: `${import.meta.env.VITE_BASE_URL}`,
+});
+
+export const noAuthClient = axios.create({
   baseURL: `${import.meta.env.VITE_BASE_URL}`,
 });
 
@@ -17,6 +21,11 @@ const updateToken = async () => {
 
   return response;
 };
+
+apiClient.interceptors.request.use((request: InternalAxiosRequestConfig) => {
+  request.headers.Authorization = `Bearer ${localStorage.getItem('accessToken')}`;
+  return request;
+});
 
 apiClient.interceptors.response.use(
   (response) => {


### PR DESCRIPTION
## 이슈 번호

#78 

## 개요

accessToken 가져오지 못하고 refreshToken 계속 요청하는 버그 수정

## 작업

- Authorization 필요한 요청은 apiClient의 `interceptors.request.use`에서 일괄적으로 토큰 주입
- Authorization 필요없는 요청은 noAuthClient 인스턴스 생성하여 사용

## 기타

- 카테고리에서 링크 공유하는 경우 비로그인에서 접근 안되는 이슈 존재. 수정 필요
