### PR TITLE
feature: 히스토리 빈 화면 퀴즈, 요약 분리

### DIFF
--- a/src/api/CategoryApi.ts
+++ b/src/api/CategoryApi.ts
@@ -65,11 +65,11 @@ const CategoryApi = {
     return response.data;
   },
 
-  createCategory: async (categoryName: string, categoryType: string) => {
+  createCategory: async (categoryName: string, categoryType: keyof CategoryTypeMapping) => {
     // 카테고리(Category)/카테고리 생성
     const response = await apiClient.post('api/category/new', {
       categoryName,
-      categoryType,
+      categoryType: CATEGORY_TYPE_MAPPING[categoryType].api,
     });
     return response.data;
   },

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -25,6 +25,7 @@ function Typography({
       $color={color}
       $hoverStyle={typographies.find((el) => el.type === hoverVariant)}
       $hoverColor={hoverColor}
+      className="typography"
     >
       {children}
     </STypography>

--- a/src/pages/Management/History/EmptyHistory/index.tsx
+++ b/src/pages/Management/History/EmptyHistory/index.tsx
@@ -1,16 +1,32 @@
 import { useNavigate } from 'react-router';
-import styled from 'styled-components';
+import { styled } from 'styled-components';
 import DefaultButton from '../../../../components/Button/DefaultButton';
 import Empty1 from '../../../../components/Empty/Empty1';
 
-function EmptyHistory() {
+interface Props {
+  type: 'all' | 'quiz' | 'summary';
+}
+
+function EmptyHistory({ type }: Props) {
   const navigate = useNavigate();
+  const highlight = (function getHighlight() {
+    if (type === 'quiz') return 'AI 퀴즈';
+    if (type === 'summary') return 'AI 요약';
+    return 'AI 퀴즈 및 요약';
+  })();
+
+  const title = `아직 생성된 ${highlight}${type === 'quiz' ? '가' : '이'} 없어요`;
+
   return (
     <Container>
-      <Empty1 title="아직 생성된 AI 퀴즈 및 요약이 없어요" highlight="AI 퀴즈 및 요약" />
+      <Empty1 title={title} highlight={highlight} />
       <ButtonContainer>
-        <DefaultButton onClick={() => navigate('/quiz/ai')}>AI 퀴즈 생성하러 가기</DefaultButton>
-        <DefaultButton onClick={() => navigate('/summary/ai')}>AI 요약 생성하러 가기</DefaultButton>
+        {(type === 'all' || type === 'quiz') && (
+          <DefaultButton onClick={() => navigate('/quiz/ai')}>AI 퀴즈 생성하러 가기</DefaultButton>
+        )}
+        {(type === 'all' || type === 'summary') && (
+          <DefaultButton onClick={() => navigate('/summary/ai')}>AI 요약 생성하러 가기</DefaultButton>
+        )}
       </ButtonContainer>
     </Container>
   );

--- a/src/pages/Management/History/HistoryPagination/index.tsx
+++ b/src/pages/Management/History/HistoryPagination/index.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from 'react';
+import ReactPaginate from 'react-paginate';
+import styled from 'styled-components';
+import { ReactComponent as NextIcon } from '../../../../assets/icons/arrow_next.svg';
+import { ReactComponent as PrevIcon } from '../../../../assets/icons/arrow_prev.svg';
+import { HistoryType } from '../../../../types/history.type';
+import EmptyHistory from '../EmptyHistory';
+import HistoryList from '../HistoryList';
+
+interface Props {
+  fetchPage: (page: number) => void;
+  histories: HistoryType[];
+  totalPages: number;
+  type: 'quiz' | 'summary';
+}
+
+function HistoryPagination({ fetchPage, histories, totalPages, type }: Props) {
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+
+  const updateList = useCallback(
+    (updatePage: number) => {
+      fetchPage(updatePage);
+      setLoading(false);
+    },
+    [fetchPage]
+  );
+
+  useEffect(() => {
+    if (loading) return;
+    updateList(page);
+  }, [loading, page, totalPages, updateList]);
+
+  useEffect(() => {
+    updateList(1);
+    setPage(1);
+  }, [updateList]);
+
+  const handlePageClick = ({ selected }: { selected: number }) => {
+    setPage(selected + 1);
+  };
+
+  if (histories.length === 0) {
+    return <EmptyHistory type={type} />;
+  }
+
+  return (
+    <>
+      <ListWrapper>
+        <HistoryList histories={histories} updateList={updateList} />
+      </ListWrapper>
+      <Pagination>
+        <ReactPaginate
+          forcePage={page - 1}
+          pageCount={totalPages}
+          previousLabel={<PrevIcon />}
+          nextLabel={<NextIcon />}
+          onPageChange={handlePageClick}
+        />
+      </Pagination>
+    </>
+  );
+}
+
+const ListWrapper = styled.div``;
+
+const Pagination = styled.div`
+  display: flex;
+  justify-content: center;
+
+  margin-top: 10px;
+
+  > ul {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+  }
+
+  a {
+    display: flex;
+    align-items: center;
+
+    color: var(--grayscale04, #9e9e9e);
+    text-align: center;
+
+    font-family: NotoSansRegular;
+    font-size: 13px;
+    font-style: normal;
+    line-height: normal;
+
+    cursor: pointer;
+  }
+
+  .selected > a {
+    color: var(--grayscale02, #424242);
+
+    font-family: NotoSansBold;
+  }
+`;
+
+export default HistoryPagination;

--- a/src/pages/Management/History/index.tsx
+++ b/src/pages/Management/History/index.tsx
@@ -41,8 +41,9 @@ function History() {
   );
 
   useEffect(() => {
-    updateList(1);
-  }, [filter, updateList]);
+    getQuizes(1);
+    getSummaries(1);
+  }, []);
 
   if (quizes.totalPages === 0 && summaries.totalPages === 0) {
     return <EmptyHistory type="all" />;

--- a/src/pages/Management/History/index.tsx
+++ b/src/pages/Management/History/index.tsx
@@ -1,64 +1,51 @@
 import { useCallback, useEffect, useState } from 'react';
-import ReactPaginate from 'react-paginate';
 import styled from 'styled-components';
 import HistoryApi from '../../../api/HistoryApi';
-import { ReactComponent as NextIcon } from '../../../assets/icons/arrow_next.svg';
-import { ReactComponent as PrevIcon } from '../../../assets/icons/arrow_prev.svg';
 import Chip from '../../../components/Chip';
 import Typography from '../../../components/Typography';
 import { HistoryType } from '../../../types/history.type';
 import EmptyHistory from './EmptyHistory';
-import HistoryList from './HistoryList';
+import HistoryPagination from './HistoryPagination';
 
 const PROBLEM = 'PROBLEM';
 const SUMMARY = 'SUMMARY';
 
+interface HistoryPageType {
+  histories: HistoryType[];
+  totalPages: number;
+}
+
 function History() {
   const [filter, setFilter] = useState<'PROBLEM' | 'SUMMARY'>(PROBLEM);
-  const [histories, setHistories] = useState<HistoryType[]>([]);
-  const [page, setPage] = useState(1);
-  const [totalPage, setTotalPage] = useState(1);
-  const [loading, setLoading] = useState(true);
+  const [quizes, setQuizes] = useState<HistoryPageType>({ histories: [], totalPages: 0 });
+  const [summaries, setSummaries] = useState<HistoryPageType>({ histories: [], totalPages: 0 });
 
   const getQuizes = async (quizPage: number) => {
     const response = await HistoryApi.getQuizList(quizPage);
     const newHistories = response.content;
-    setHistories(newHistories);
-    setTotalPage(response.totalPages);
+    setQuizes({ histories: newHistories, totalPages: response.totalPages });
   };
 
   const getSummaries = async (summaryPage: number) => {
     const response = await HistoryApi.getSummaryList(summaryPage);
     const newHistories = response.content;
-    setHistories(newHistories);
-    setTotalPage(response.totalPages);
+    setSummaries({ histories: newHistories, totalPages: response.totalPages });
   };
 
   const updateList = useCallback(
     (updatePage: number) => {
       if (filter === 'PROBLEM') getQuizes(updatePage);
       if (filter === 'SUMMARY') getSummaries(updatePage);
-      setLoading(false);
     },
     [filter]
   );
 
   useEffect(() => {
-    if (loading) return;
-    updateList(page);
-  }, [loading, page, updateList]);
-
-  useEffect(() => {
     updateList(1);
-    setPage(1);
   }, [filter, updateList]);
 
-  const handlePageClick = ({ selected }: { selected: number }) => {
-    setPage(selected + 1);
-  };
-
-  if (histories.length === 0) {
-    return <EmptyHistory />;
+  if (quizes.totalPages === 0 && summaries.totalPages === 0) {
+    return <EmptyHistory type="all" />;
   }
 
   return (
@@ -76,18 +63,12 @@ function History() {
           </Chip>
         </ChipWrapper>
       </Header>
-      <ListWrapper>
-        <HistoryList histories={histories} updateList={updateList} />
-      </ListWrapper>
-      <Pagination>
-        <ReactPaginate
-          forcePage={page - 1}
-          pageCount={totalPage}
-          previousLabel={<PrevIcon />}
-          nextLabel={<NextIcon />}
-          onPageChange={handlePageClick}
-        />
-      </Pagination>
+      <HistoryPagination
+        type={filter === PROBLEM ? 'quiz' : 'summary'}
+        fetchPage={updateList}
+        histories={filter === PROBLEM ? quizes.histories : summaries.histories}
+        totalPages={filter === PROBLEM ? quizes.totalPages : summaries.totalPages}
+      />
     </Wrapper>
   );
 }
@@ -116,42 +97,6 @@ const ChipWrapper = styled.div`
   display: flex;
   gap: 12px;
   align-items: center;
-`;
-
-const ListWrapper = styled.div``;
-
-const Pagination = styled.div`
-  display: flex;
-  justify-content: center;
-
-  margin-top: 10px;
-
-  > ul {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-  }
-
-  a {
-    display: flex;
-    align-items: center;
-
-    color: var(--grayscale04, #9e9e9e);
-    text-align: center;
-
-    font-family: NotoSansRegular;
-    font-size: 13px;
-    font-style: normal;
-    line-height: normal;
-
-    cursor: pointer;
-  }
-
-  .selected > a {
-    color: var(--grayscale02, #424242);
-
-    font-family: NotoSansBold;
-  }
 `;
 
 export default History;

--- a/src/pages/Management/MyCategory/ItemDetail/SummaryItemDetail.tsx
+++ b/src/pages/Management/MyCategory/ItemDetail/SummaryItemDetail.tsx
@@ -83,7 +83,7 @@ function SummaryItemDetail() {
         {showCategoryModal && (
           <CategoryModal
             onClose={() => setShowCategoryModal(false)}
-            categoryType="quiz"
+            categoryType="summary"
             contentId={Number(params.get('id') || -1)}
             generateType={currentSummary.aiGeneratedSummaryId ? 'ai' : 'user'}
           />

--- a/src/pages/Summary/SummaryComplete/index.tsx
+++ b/src/pages/Summary/SummaryComplete/index.tsx
@@ -7,6 +7,7 @@ import LinkButton from '../../../components/Button/LinkButton';
 import PDFButton from '../../../components/Button/PDFButton';
 import SaveButton from '../../../components/Button/SaveButton';
 import CategoryModal from '../../../components/Modal/CategoryModal';
+import Scrollbar from '../../../components/Scrollbar';
 import Typography from '../../../components/Typography';
 import authState from '../../../recoil/atoms/authState';
 import { SummaryType } from '../../../types/summary.type';
@@ -45,7 +46,7 @@ function SummaryComplete({ type }: Props) {
   if (!summary) return <div />;
 
   return (
-    <>
+    <Wrapper>
       <MainWrapper>
         <TitleWrapper>
           <Typography variant="subtitle" color="mainMintDark">
@@ -83,15 +84,22 @@ function SummaryComplete({ type }: Props) {
           generateType={type}
         />
       )}
-    </>
+    </Wrapper>
   );
 }
+
+const Wrapper = styled.div`
+  display: flex;
+`;
 
 const MainWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
   padding: 40px;
+  width: 800px;
+  overflow-y: auto;
+  ${Scrollbar}
 
   gap: 20px;
 

--- a/src/pages/Summary/SummaryComplete/index.tsx
+++ b/src/pages/Summary/SummaryComplete/index.tsx
@@ -54,7 +54,9 @@ function SummaryComplete({ type }: Props) {
           </Typography>
           <Typography variant="subtitle">{summary.summaryTitle}</Typography>
         </TitleWrapper>
-        <Typography variant="body3">{summary.summaryContent}</Typography>
+        <ContentWrapper>
+          <Typography variant="body3">{summary.summaryContent}</Typography>
+        </ContentWrapper>
       </MainWrapper>
 
       <SideWrapper>
@@ -112,6 +114,12 @@ const TitleWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 12px;
+`;
+
+const ContentWrapper = styled.div`
+  .typography {
+    word-wrap: break-word;
+  }
 `;
 
 const SideWrapper = styled.div`


### PR DESCRIPTION
## 이슈 번호

#94 

## 개요
히스토리 빈 화면 퀴즈, 요약 분리

(#90 브랜치에서 갈라져 나왔습니다)

## 작업

- History 컴포넌트 구조 변경
- 퀴즈, 요약 별 빈 화면 구현

## 기타

<img width="1512" alt="스크린샷 2024-05-15 오후 7 02 25" src="https://github.com/capstone-five-ai/Qtudy-FE/assets/45119238/6e97218e-97db-4bec-b941-a1f5619d0cae">

