### PR TITLE
fix: 디자인 피드백 5차 반영

### DIFF
--- a/src/components/Button/PlainButton.tsx
+++ b/src/components/Button/PlainButton.tsx
@@ -64,12 +64,11 @@ const getVariantStyle = ($variant: PlainButtonVariant) => {
         color: ${({ theme }) => theme.colors.grayScale03};
         background: ${({ theme }) => theme.colors.grayScale08};
         box-shadow: 4px 2px 16px 0px rgba(189, 189, 189, 0.28);
-        border: 1px solid ${({ theme }) => theme.colors.grayScale06};
+        border: 0.8px solid ${({ theme }) => theme.colors.grayScale06};
 
         &:hover {
           color: ${({ theme }) => theme.colors.grayScale02};
-          background: ${({ theme }) => theme.colors.grayScale06};
-          box-shadow: 4px 2px 16px 0px rgba(142, 142, 142, 0.28);
+          box-shadow: 4px 2px 16px 0px rgba(142, 142, 142, 0.12);
         }
       `;
   }
@@ -93,5 +92,6 @@ const StyledButton = styled.button<{
     background: ${({ theme }) => theme.colors.grayScale06};
     color: ${({ theme }) => theme.colors.grayScale09};
     box-shadow: none;
+    cursor: default;
   }
 `;

--- a/src/components/Chip/FileTypeChip.tsx
+++ b/src/components/Chip/FileTypeChip.tsx
@@ -18,7 +18,7 @@ function FileTypeChip({
   return (
     <Wrapper type="button" {...props} $selected={selected}>
       <Typography
-        variant="detail"
+        variant="button"
         color={selected ? 'grayScale09' : 'mainMintDark'}
       >
         {children}

--- a/src/components/Form/QuizGenerationForm.tsx
+++ b/src/components/Form/QuizGenerationForm.tsx
@@ -179,6 +179,7 @@ const StyledQuizContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
+  padding-top: 4px;
 `;
 
 const StyledChoiceListContainer = styled.div`

--- a/src/components/Form/QuizGenerationForm.tsx
+++ b/src/components/Form/QuizGenerationForm.tsx
@@ -14,6 +14,7 @@ interface QuizFormProps {
   quizType: string;
   quizContent: QuizType;
   setQuizContent: (newQuizContent: QuizType) => void;
+  showWarning?: boolean;
 }
 
 const MAX_OPTION_COUNT = 10;
@@ -22,6 +23,7 @@ function QuizGenerationForm({
   quizType,
   quizContent,
   setQuizContent,
+  showWarning = false,
 }: QuizFormProps) {
   const [isCommentOpen, setIsCommentOpen] = useState(false);
   const { fireToast } = useToast();
@@ -106,6 +108,8 @@ function QuizGenerationForm({
           name="problemName"
           value={quizContent.problemName}
           onChange={handleChangeQuestion}
+          showWarning={showWarning && quizContent.problemName === ''}
+          warningMessage="입력 필수인 항목입니다."
         />
         {quizType === '객관식' && (
           <>
@@ -133,6 +137,8 @@ function QuizGenerationForm({
                     value={choice}
                     onChange={handleChangeChoice}
                     onDelete={handleDeleteChoice}
+                    showWarning={showWarning && choice === ''}
+                    warningMessage="빈 항목입니다."
                   />
                 </StyledChoiceWrapper>
               ))}
@@ -154,6 +160,8 @@ function QuizGenerationForm({
         setIsCommentOpen={setIsCommentOpen}
         isEdit
         onChange={handleCommentaryChange}
+        showWarning={showWarning && quizContent.problemCommentary === ''}
+        warningMessage="입력 필수인 항목입니다."
       />
     </StyledContainer>
   );

--- a/src/components/Header/ContentHeader.tsx
+++ b/src/components/Header/ContentHeader.tsx
@@ -68,7 +68,7 @@ const StyledContentContainer = styled.div`
   padding: 28px 0px 20px;
 
   .title {
-    ${({ theme }) => theme.typography.h3};
+    ${({ theme }) => theme.typography.h2};
     color: ${({ theme }) => theme.colors.grayScale02};
   }
 

--- a/src/components/InputField/CommentInputField.tsx
+++ b/src/components/InputField/CommentInputField.tsx
@@ -178,6 +178,10 @@ const StyledEditContent = styled(StyledContent)<{ $warning: boolean }>`
   background: ${({ theme }) => theme.colors.grayScale09};
   border: 0.5px solid transparent;
 
+  &:hover {
+    box-shadow: 0px 0px 4px 0px rgba(117, 117, 117, 0.32);
+  }
+
   ${({ $warning, theme }) =>
     $warning &&
     css`

--- a/src/components/InputField/CommentInputField.tsx
+++ b/src/components/InputField/CommentInputField.tsx
@@ -16,6 +16,8 @@ interface CommentInputFieldProps {
 
 interface CommentEditInputFieldProps extends CommentInputFieldProps {
   isEdit?: boolean;
+  showWarning?: boolean;
+  warningMessage?: string;
   onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   setIsEdit?: (value: boolean) => void;
 }
@@ -66,6 +68,8 @@ export function CommentEditInputField({
   answer,
   commentary,
   isCommentOpen,
+  showWarning = false,
+  warningMessage,
   setIsCommentOpen,
   onChange,
   setIsEdit,
@@ -94,25 +98,28 @@ export function CommentEditInputField({
               <span className="answer">{answer && getCircleNum(answer)}</span>
             </div>
           )}
-          <StyledEditContent>
-            <StyledTextarea
-              ref={textareaRef}
-              placeholder="해설을 입력해주세요."
-              value={commentary}
-              onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-                onChange && onChange(event);
-              }}
-              disabled={!isEdit}
-            />
-            {!isEdit && (
-              <EditIcon
-                className="icon"
-                onClick={() => {
-                  setIsEdit && setIsEdit(true);
+          <div>
+            <StyledEditContent $warning={showWarning}>
+              <StyledTextarea
+                ref={textareaRef}
+                placeholder="해설을 입력해주세요."
+                value={commentary}
+                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                  onChange && onChange(event);
                 }}
+                disabled={!isEdit}
               />
-            )}
-          </StyledEditContent>
+              {!isEdit && (
+                <EditIcon
+                  className="icon"
+                  onClick={() => {
+                    setIsEdit && setIsEdit(true);
+                  }}
+                />
+              )}
+            </StyledEditContent>
+            <ErrorMessage $show={showWarning}>{warningMessage}</ErrorMessage>
+          </div>
         </>
       )}
     </StyledContainer>
@@ -167,8 +174,15 @@ const StyledDefaultContent = styled(StyledContent)`
   background: ${({ theme }) => theme.colors.mainMintLight};
 `;
 
-const StyledEditContent = styled(StyledContent)`
+const StyledEditContent = styled(StyledContent)<{ $warning: boolean }>`
   background: ${({ theme }) => theme.colors.grayScale09};
+  border: 0.5px solid transparent;
+
+  ${({ $warning, theme }) =>
+    $warning &&
+    css`
+      border-color: ${theme.colors.errorRed};
+    `}
 `;
 
 const StyledTextarea = styled.textarea`
@@ -203,4 +217,11 @@ const StyledText = styled.div`
   color: ${({ theme }) => theme.colors.grayScale02};
   ${({ theme }) => theme.typography.body2};
   white-space: pre-wrap;
+`;
+
+const ErrorMessage = styled.div<{ $show: boolean }>`
+  display: ${({ $show }) => ($show ? 'block' : 'none')};
+  color: ${({ theme }) => theme.colors.errorRed};
+  ${({ theme }) => theme.typography.caption3};
+  margin-top: 4px;
 `;

--- a/src/components/InputField/FileNameInputField.tsx
+++ b/src/components/InputField/FileNameInputField.tsx
@@ -6,9 +6,9 @@ function FileNameInputField(props: NameInputFieldProps) {
   return (
     <StyledContainer>
       <Typography variant="subtitle" color="grayScale02">
-        파일명
+        제목
       </Typography>
-      <NameInputField placeholder="파일명을 입력해주세요." {...props} />
+      <NameInputField placeholder="제목을 입력해주세요." {...props} />
     </StyledContainer>
   );
 }

--- a/src/components/InputField/QuizInputField.tsx
+++ b/src/components/InputField/QuizInputField.tsx
@@ -12,6 +12,8 @@ interface QuizInputFieldProps
   type: 'question' | 'choice';
   index: number;
   isEdit?: boolean;
+  showWarning?: boolean;
+  warningMessage?: string;
   setIsEdit?: (value: boolean) => void;
   onChange: (event: React.ChangeEvent<HTMLInputElement>, index: number) => void;
   onDelete?: (index: number) => void;
@@ -21,46 +23,54 @@ function QuizInputField({
   type,
   index,
   isEdit,
+  showWarning = false,
+  warningMessage,
   setIsEdit,
   onChange,
   onDelete,
   ...props
 }: QuizInputFieldProps) {
   return (
-    <StyledContainer $type={type}>
-      <StyledInput
-        placeholder={PLACEHOLDER[type]}
-        onChange={(event) => {
-          onChange(event, index);
-        }}
-        disabled={!isEdit}
-        {...props}
-      />
-      <StyledIconContainer>
-        {!isEdit && (
-          <EditIcon
-            className="icon"
-            onClick={() => {
-              setIsEdit && setIsEdit(true);
-            }}
-          />
-        )}
-        {type === 'choice' && (
-          <DeleteIcon
-            className="icon"
-            onClick={() => {
-              onDelete && onDelete(index);
-            }}
-          />
-        )}
-      </StyledIconContainer>
-    </StyledContainer>
+    <div style={{ width: '100%' }}>
+      <StyledContainer $type={type} $warning={showWarning}>
+        <StyledInput
+          placeholder={PLACEHOLDER[type]}
+          onChange={(event) => {
+            onChange(event, index);
+          }}
+          disabled={!isEdit}
+          {...props}
+        />
+        <StyledIconContainer>
+          {!isEdit && (
+            <EditIcon
+              className="icon"
+              onClick={() => {
+                setIsEdit && setIsEdit(true);
+              }}
+            />
+          )}
+          {type === 'choice' && (
+            <DeleteIcon
+              className="icon"
+              onClick={() => {
+                onDelete && onDelete(index);
+              }}
+            />
+          )}
+        </StyledIconContainer>
+      </StyledContainer>
+      <ErrorMessage $show={showWarning}>{warningMessage}</ErrorMessage>
+    </div>
   );
 }
 
 export default QuizInputField;
 
-const StyledContainer = styled.div<{ $type: 'question' | 'choice' }>`
+const StyledContainer = styled.div<{
+  $type: 'question' | 'choice';
+  $warning: boolean;
+}>`
   display: flex;
   align-items: center;
   ${({ $type }) =>
@@ -72,6 +82,13 @@ const StyledContainer = styled.div<{ $type: 'question' | 'choice' }>`
   background: ${(props) => props.theme.colors.grayScale09};
   padding: 12px 16px;
   border-radius: 8px;
+  border: 0.5px solid transparent;
+
+  ${({ $warning, theme }) =>
+    $warning &&
+    css`
+      border-color: ${theme.colors.errorRed};
+    `}
 `;
 
 const StyledInput = styled.input`
@@ -94,4 +111,11 @@ const StyledIconContainer = styled.div`
     height: 20px;
     cursor: pointer;
   }
+`;
+
+const ErrorMessage = styled.div<{ $show: boolean }>`
+  display: ${({ $show }) => ($show ? 'block' : 'none')};
+  color: ${({ theme }) => theme.colors.errorRed};
+  ${({ theme }) => theme.typography.caption3};
+  margin-top: 4px;
 `;

--- a/src/components/InputField/QuizInputField.tsx
+++ b/src/components/InputField/QuizInputField.tsx
@@ -84,6 +84,10 @@ const StyledContainer = styled.div<{
   border-radius: 8px;
   border: 0.5px solid transparent;
 
+  &:hover {
+    box-shadow: 0px 0px 4px 0px rgba(117, 117, 117, 0.32);
+  }
+
   ${({ $warning, theme }) =>
     $warning &&
     css`

--- a/src/components/Modal/SaveToCategoryModal.tsx
+++ b/src/components/Modal/SaveToCategoryModal.tsx
@@ -78,10 +78,14 @@ function SaveToCategoryModal({
         await postQuizToCategory(saveCategoryIds, contentId);
 
       onClose();
-      fireToast({ icon: <SaveIcon />, message: '카테고리에 저장되었습니다!' });
+      fireToast({
+        icon: <SaveIcon />,
+        message: '카테고리에 저장되었습니다!',
+        duration: 3000,
+      });
     } catch (e) {
       if (e instanceof AxiosError)
-        fireToast({ message: e.response?.data.errorMessage });
+        fireToast({ message: e.response?.data.errorMessage, duration: 3000 });
     }
   };
 

--- a/src/components/Sidebar/GenerateSidebar.tsx
+++ b/src/components/Sidebar/GenerateSidebar.tsx
@@ -49,7 +49,7 @@ function GenerateSidebar<T extends object>({
                 value={inputOption.fileName as string}
                 onChange={handleFileNameChange}
                 disabled={inputFieldDisabled}
-                errorMessage="중복되는 파일명입니다."
+                errorMessage="중복되는 제목입니다."
                 isError={inputOption.isDuplicatedFileName === true}
               />
             )}

--- a/src/components/Wrapper/GenerateMethodWrapper.tsx
+++ b/src/components/Wrapper/GenerateMethodWrapper.tsx
@@ -30,7 +30,7 @@ const StyledContainer = styled.div`
   margin-top: 86px;
 
   .text {
-    ${({ theme }) => theme.typography.caption2};
+    ${({ theme }) => theme.typography.h4};
     color: ${({ theme }) => theme.colors.grayScale03};
     text-align: center;
     margin-bottom: 52px;

--- a/src/containers/CategoryDetailPage/TopButtonBar.tsx
+++ b/src/containers/CategoryDetailPage/TopButtonBar.tsx
@@ -10,6 +10,7 @@ interface TopButtonBarProps {
   handleReturnToList?: () => void;
   handleEdit?: () => void;
   handleCancel?: () => void;
+  margin?: string;
 }
 
 function TopButtonBar({
@@ -19,9 +20,10 @@ function TopButtonBar({
   handleReturnToList,
   handleEdit,
   handleCancel,
+  margin,
 }: TopButtonBarProps) {
   return (
-    <StyledContainer>
+    <StyledContainer $margin={margin}>
       {isEdit ? (
         <>
           <StyledButton type="button" onClick={handleCancel}>
@@ -61,11 +63,11 @@ function TopButtonBar({
 
 export default TopButtonBar;
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.div<{ $margin: string | undefined }>`
   display: flex;
   justify-content: space-between;
-  margin-right: 16px;
-  margin-bottom: 24px;
+  width: 724px;
+  margin-bottom: ${({ $margin }) => $margin || '24px'};
 `;
 
 const StyledButton = styled.button`

--- a/src/containers/CategoryDetailPage/TopButtonBar.tsx
+++ b/src/containers/CategoryDetailPage/TopButtonBar.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 interface TopButtonBarProps {
   isEdit?: boolean;
+  disabledComplete?: boolean;
   handleComplete?: () => void;
   handleReturnToList?: () => void;
   handleEdit?: () => void;
@@ -13,6 +14,7 @@ interface TopButtonBarProps {
 
 function TopButtonBar({
   isEdit = false,
+  disabledComplete = false,
   handleComplete,
   handleReturnToList,
   handleEdit,
@@ -27,7 +29,11 @@ function TopButtonBar({
               편집 취소
             </Typography>
           </StyledButton>
-          <StyledButton type="button" onClick={handleComplete}>
+          <StyledButton
+            type="button"
+            onClick={handleComplete}
+            disabled={disabledComplete}
+          >
             <CheckIcon />
             <Typography variant="button" color="grayScale03">
               편집 완료
@@ -71,5 +77,10 @@ const StyledButton = styled.button`
     path {
       fill: ${({ theme }) => theme.colors.mainMintDark};
     }
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.4;
   }
 `;

--- a/src/containers/CategoryPage/Category.tsx
+++ b/src/containers/CategoryPage/Category.tsx
@@ -66,7 +66,6 @@ function Category({
             ref={inputRef}
             value={newCategoryName}
             onChange={(e) => setNewCategoryName(e.target.value)}
-            placeholder="파일명을 입력해주세요."
           />
           <div className="icon-list">
             <CompleteIcon
@@ -165,16 +164,11 @@ const StyledContainer = styled.button<{ $active: boolean }>`
 `;
 
 const StyledInput = styled.input`
+  width: 100%;
   border: none;
-  color: ${(props) => props.theme.colors.grayScale02};
   background-color: transparent;
   padding: 0;
 
   ${({ theme }) => theme.typography.body2};
-
-  &::placeholder {
-    color: ${(props) => props.theme.colors.grayScale05};
-  }
-
-  width: 100%;
+  color: ${(props) => props.theme.colors.grayScale02};
 `;

--- a/src/containers/CategoryPage/Category.tsx
+++ b/src/containers/CategoryPage/Category.tsx
@@ -30,16 +30,20 @@ function Category({
   const { fireToast } = useToast();
 
   const handleSubmitCategoryName = async () => {
-    try {
-      await editCategoryName(
-        String(category.categoryId),
-        category.categoryType,
-        newCategoryName
-      );
+    if (category.categoryName !== newCategoryName) {
+      try {
+        await editCategoryName(
+          String(category.categoryId),
+          category.categoryType,
+          newCategoryName
+        );
+        setEditMode(false);
+        refetchCategory();
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
       setEditMode(false);
-      refetchCategory();
-    } catch (e) {
-      console.error(e);
     }
   };
 

--- a/src/containers/CategoryPage/CategorySection.tsx
+++ b/src/containers/CategoryPage/CategorySection.tsx
@@ -110,7 +110,7 @@ const StyledContentWrapper = styled(ContentWrapper)`
 
   .no-category {
     width: 100%;
-    ${({ theme }) => theme.typography.detail};
+    ${({ theme }) => theme.typography.h3};
     color: ${({ theme }) => theme.colors.grayScale04};
 
     display: flex;

--- a/src/containers/CategoryPage/CategorySidebar.tsx
+++ b/src/containers/CategoryPage/CategorySidebar.tsx
@@ -37,7 +37,7 @@ function CategorySidebar({
       <StyledContainer>
         <CategoryTabBar currentType={currentType} />
         <StyleTitleContainer>
-          <Typography variant="h4" color="grayScale02">
+          <Typography variant="h3" color="grayScale02">
             {CATEGORY_TYPE[currentType]}
           </Typography>
           <button
@@ -129,7 +129,7 @@ const StyledCategoryListContainer = styled.div`
   flex: 1;
 
   .no-category {
-    ${({ theme }) => theme.typography.detail};
+    ${({ theme }) => theme.typography.h3};
     color: ${({ theme }) => theme.colors.grayScale04};
     margin-top: 84px;
     text-align: center;

--- a/src/containers/HistoryPage/HistoryItem.tsx
+++ b/src/containers/HistoryPage/HistoryItem.tsx
@@ -1,4 +1,5 @@
 import { deleteFile, updateFileName } from '@/apis/fileApi';
+import { ReactComponent as CheckIcon } from '@/assets/icons/complete.svg';
 import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
 import PDFDownloadButton from '@/components/Button/PDFDownloadButton';
 import DeleteIcon from '@/components/Icon/DeleteIcon';
@@ -14,7 +15,7 @@ import {
 import useToast from '@/hooks/useToast';
 import { HistoryType } from '@/types/history.type';
 import { convertToKRTime } from '@/utils/convertToKRTime';
-import { FormEvent, useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
@@ -24,19 +25,12 @@ type Props = {
 };
 
 function HistoryItem({ history, updateList }: Props) {
-  const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
   const [editMode, setEditMode] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [fileName, setFileName] = useState(history.fileName);
   const [newFileName, setNewFileName] = useState(fileName);
   const { fireToast } = useToast();
-
-  useEffect(() => {
-    if (inputRef.current === null) return;
-    inputRef.current.disabled = false;
-    inputRef.current.focus();
-  }, [editMode]);
 
   const getDateFormat = (dateStr: string) => {
     const date = convertToKRTime(dateStr);
@@ -57,13 +51,7 @@ function HistoryItem({ history, updateList }: Props) {
     setShowDeleteModal(true);
   };
 
-  const submitFileName = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    await editFileName();
-  };
-
-  const editFileName = async () => {
+  const handleEditFileName = async () => {
     await updateFileName(history.fileId, newFileName);
     setEditMode(false);
     setFileName(newFileName);
@@ -87,15 +75,14 @@ function HistoryItem({ history, updateList }: Props) {
       </Filter>
       <FileName>
         {editMode ? (
-          <Form onSubmit={submitFileName}>
+          <>
             <Input
-              ref={inputRef}
               value={newFileName}
               onChange={(e) => setNewFileName(e.target.value)}
               placeholder="파일명을 입력해주세요."
-              onBlur={editFileName}
             />
-          </Form>
+            <CheckIcon onClick={handleEditFileName} cursor="pointer" />
+          </>
         ) : (
           <>
             <FileNameWrapper type="button" onClick={handleClickFile}>
@@ -178,6 +165,9 @@ const Wrapper = styled.div`
 `;
 
 const FileNameWrapper = styled.button`
+  width: 200px;
+  text-align: left;
+
   border: none;
   padding: 0;
   margin: 0;
@@ -193,11 +183,8 @@ const FileNameWrapper = styled.button`
   }
 `;
 
-const Form = styled.form`
-  width: 100%;
-`;
-
 const Input = styled.input`
+  width: 200px;
   border: none;
   color: ${(props) => props.theme.colors.grayScale02};
   background-color: transparent;
@@ -208,8 +195,6 @@ const Input = styled.input`
     ${({ theme }) => theme.typography.caption3};
     color: ${(props) => props.theme.colors.grayScale05};
   }
-
-  width: 100%;
 `;
 
 export default HistoryItem;

--- a/src/containers/HistoryPage/HistoryItem.tsx
+++ b/src/containers/HistoryPage/HistoryItem.tsx
@@ -79,7 +79,7 @@ function HistoryItem({ history, updateList }: Props) {
             <Input
               value={newFileName}
               onChange={(e) => setNewFileName(e.target.value)}
-              placeholder="파일명을 입력해주세요."
+              placeholder="제목을 입력해주세요."
             />
             <CheckIcon onClick={handleEditFileName} cursor="pointer" />
           </>

--- a/src/containers/HistoryPage/HistoryList.tsx
+++ b/src/containers/HistoryPage/HistoryList.tsx
@@ -26,7 +26,7 @@ function HistoryList({ histories, updateList }: Props) {
         </Filter>
         <FileName>
           <Typography variant="button" color="grayScale03">
-            파일명
+            제목
           </Typography>
         </FileName>
         <CreatedTime>

--- a/src/containers/QuizUserPage/GenerateSection.tsx
+++ b/src/containers/QuizUserPage/GenerateSection.tsx
@@ -108,13 +108,13 @@ export default GenerateSection;
 
 const StyledContent = styled.div`
   flex: 1;
-  padding: 40px 0;
+  padding: 36px 0;
+  padding-top: 36px;
 `;
 
 const StyledInnerContent = styled.div`
   height: 100%;
-  padding-left: 40px;
-  padding-right: 20px;
+  padding: 0 20px 4px 40px;
 
   overflow-y: scroll;
   ${Scrollbar}

--- a/src/containers/QuizUserPage/GenerateSection.tsx
+++ b/src/containers/QuizUserPage/GenerateSection.tsx
@@ -27,6 +27,7 @@ const initialQuizContent: QuizType = {
 };
 
 function GenerateSection() {
+  const [showWarning, setShowWarning] = useState(false);
   const showLoading = useRecoilValue(loadingState);
   const [quizContent, setQuizContent] = useState<QuizType>(initialQuizContent);
   const [inputOption, setInputOption] = useState<GenerateQuizOption>({
@@ -41,6 +42,17 @@ function GenerateSection() {
   }, [inputOption.type]);
 
   const handleSubmit = () => {
+    if (
+      quizContent.problemName === '' ||
+      quizContent.problemCommentary === '' ||
+      quizContent.problemChoices.includes('')
+    ) {
+      setShowWarning(true);
+      return;
+    }
+
+    setShowWarning(false);
+
     let payload;
 
     if (inputOption.type === '객관식') {
@@ -71,6 +83,7 @@ function GenerateSection() {
             quizType={inputOption.type}
             quizContent={quizContent}
             setQuizContent={setQuizContent}
+            showWarning={showWarning}
           />
         </StyledInnerContent>
       </StyledContent>
@@ -81,7 +94,6 @@ function GenerateSection() {
         handleSubmit={handleSubmit}
         generateButtonDisabled={
           Object.values(inputOption).includes('') ||
-          quizContent.problemName === '' ||
           (inputOption.type === '객관식' &&
             quizContent.problemAnswer === '-1') ||
           (inputOption.type === '객관식' &&

--- a/src/pages/CategoryQuizEditPage.tsx
+++ b/src/pages/CategoryQuizEditPage.tsx
@@ -77,6 +77,12 @@ function CategoryQuizEditPage() {
           isEdit
           handleCancel={handleCancel}
           handleComplete={handleEdit}
+          disabledComplete={
+            quizContent.problemName === '' ||
+            quizContent.problemCommentary === '' ||
+            quizContent.problemChoices.includes('') ||
+            (quizContent.problemAnswer === '-1' && quizType === '객관식')
+          }
         />
         <StyledInnerContainer>
           <QuizGenerationForm

--- a/src/pages/CategoryQuizEditPage.tsx
+++ b/src/pages/CategoryQuizEditPage.tsx
@@ -83,6 +83,7 @@ function CategoryQuizEditPage() {
             quizContent.problemChoices.includes('') ||
             (quizContent.problemAnswer === '-1' && quizType === '객관식')
           }
+          margin="20px"
         />
         <StyledInnerContainer>
           <QuizGenerationForm
@@ -101,13 +102,17 @@ export default CategoryQuizEditPage;
 
 const StyledContent = styled.div`
   flex: 1;
-  padding: 24px 20px 24px 40px;
+  padding: 24px 0;
 
   display: flex;
   flex-direction: column;
+  align-items: center;
 `;
 
 const StyledInnerContainer = styled.div`
   overflow-y: scroll;
   ${Scrollbar}
+
+  width: 100%;
+  padding: 0 20px 4px 40px;
 `;

--- a/src/pages/CategorySummaryDetailPage.tsx
+++ b/src/pages/CategorySummaryDetailPage.tsx
@@ -76,4 +76,6 @@ const StyledContent = styled.div<{ $isWriter: boolean }>`
 
   display: flex;
   flex-direction: column;
+
+  background: pink;
 `;

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -42,7 +42,8 @@ const typography = {
   h4: TYPOGRAPHY({
     font: 'Noto Sans KR',
     weight: 500,
-    size: 16,
+    size: 15,
+    lineHeight: 160,
   }),
   subtitle: TYPOGRAPHY({
     font: 'Noto Sans KR',

--- a/src/types/typography.type.ts
+++ b/src/types/typography.type.ts
@@ -38,9 +38,9 @@ export const typographies: Style[] = [
   {
     type: 'h4',
     font: 'Noto Sans KR',
-    size: 16,
+    size: 15,
     weight: 500,
-    lineHeight: 'auto',
+    lineHeight: '160%',
     letterSpacing: 0,
   },
   {


### PR DESCRIPTION
## 이슈 번호

- resolved #110 

## 개요

5차 디자인 피드백 및 기능 오류 피드백을 반영합니다.

## 작업

- 토스트 메시지 duration 시간 변경
- CTA 버튼 디자인 재조정
- 카테고리 이름 수정 시, placeholder 안보이도록 변경
- 히스토리 파일명 수정 시, 아이콘을 클릭해야 수정 완료되도록 변경
- 이름 변경이 없을 경우 편집 완료가 안되는 문제 해결
- 빈 항목에 대한 디자인 추가
- 폰트 수정 반영
- `파일명 -> 제목` 워딩 수정
- 퀴즈 생성 필드 hover 디자인 반영
